### PR TITLE
feat: Add --verbose flag to scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
       - id: mypy
         args: [--ignore-missing-imports, --strict, --explicit-package-bases]
         files: ^scripts/
+        additional_dependencies: [types-PyYAML]
 
   # Security checks
   - repo: https://github.com/PyCQA/bandit

--- a/scripts/test_dropbox_connection.py
+++ b/scripts/test_dropbox_connection.py
@@ -91,8 +91,14 @@ def _test_thumbnail(client: DropboxClient, source_folder: str, image_extensions:
 
 def main() -> None:
     """Test Dropbox connection and list files."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Test Dropbox connection and configuration")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    args = parser.parse_args()
+
     # Setup logging
-    setup_logging()
+    setup_logging(args.verbose)
     logger = get_logger(__name__)
 
     print("=" * 60)

--- a/scripts/train_face_model.py
+++ b/scripts/train_face_model.py
@@ -13,6 +13,7 @@ Usage:
     python scripts/train_face_model.py
 """
 
+import argparse
 import glob
 import os
 import sys
@@ -26,8 +27,13 @@ import yaml  # noqa: E402
 from scripts.face_recognizer.providers.local_provider import LocalFaceRecognitionProvider  # noqa: E402
 from scripts.logging_utils import get_logger, setup_logging  # noqa: E402
 
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Train face recognition model")
+parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+args = parser.parse_args()
+
 # Setup logging
-setup_logging()
+setup_logging(args.verbose)
 logger = get_logger(__name__)
 
 


### PR DESCRIPTION
## Summary
- Adds `--verbose` command line argument to `test_dropbox_connection.py` and `train_face_model.py` scripts
- Enables users to control logging verbosity via CLI, integrating with the centralized logging system
- Adds `types-PyYAML` to pre-commit mypy hook dependencies to fix type checking

## Test plan
- [ ] Run `python scripts/test_dropbox_connection.py --verbose` and verify detailed logging output
- [ ] Run `python scripts/train_face_model.py --verbose` and verify detailed logging output
- [ ] Run scripts without `--verbose` flag and verify normal logging behavior
- [ ] Run `pre-commit run --all-files` to verify mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)