### PR TITLE
feat: Disable automatic Claude PR review on push (fixes #58)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,11 @@
 name: Claude Code Review
 
 on:
-  # Manual trigger only - use "Run workflow" button in GitHub Actions tab
+  # Trigger on comment with "/claude-review" keyword
+  issue_comment:
+    types: [created]
+
+  # Manual trigger via GitHub Actions UI
   workflow_dispatch:
     inputs:
       pr_number:
@@ -9,20 +13,23 @@ on:
         required: true
         type: number
 
-  # Optional: Trigger on PR label (uncomment to enable)
-  # pull_request:
-  #   types: [labeled]
-
   # Note: Automatic triggers on push (synchronize) have been disabled per issue #58
   # This prevents Claude from reviewing after each push to a PR
+  #
   # To trigger a review:
-  #   1. Use the "Run workflow" button in the Actions tab
-  #   2. Or add a label trigger (uncomment the pull_request section above)
+  #   1. Comment "/claude-review" on any PR
+  #   2. Or use the "Run workflow" button in the Actions tab
 
 jobs:
   claude-review:
-    # Only allow amendez13 to trigger Claude Code Review
-    if: github.actor == 'amendez13'
+    # Only allow amendez13 to trigger, and only on PR comments with "/claude-review"
+    if: |
+      github.actor == 'amendez13' && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         contains(github.event.comment.body, '/claude-review'))
+      )
 
     runs-on: ubuntu-latest
     permissions:
@@ -45,7 +52,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+            PR NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
 
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -787,11 +787,21 @@ The project includes two GitHub Actions workflows for automated code assistance 
 
 ### Claude Code Review (`.github/workflows/claude-code-review.yml`)
 
-**Purpose:** Manual PR review workflow for getting detailed code review feedback from Claude.
+**Purpose:** On-demand PR review workflow for getting detailed code review feedback from Claude.
 
-**Trigger:** Manual workflow dispatch only (as of issue #58)
+**Triggers:**
+- Comment with `/claude-review` on any pull request
+- Manual workflow dispatch via GitHub Actions UI
 
 **How to Use:**
+
+*Option 1: Comment Trigger (Recommended)*
+Simply comment `/claude-review` on any PR to trigger a review:
+```
+/claude-review
+```
+
+*Option 2: Manual Trigger via UI*
 1. Go to the Actions tab in GitHub
 2. Select "Claude Code Review" workflow
 3. Click "Run workflow"
@@ -804,8 +814,8 @@ The project includes two GitHub Actions workflows for automated code assistance 
 - Posts review comments directly on the PR
 
 **Configuration Notes:**
-- **Manual trigger only:** Automatic triggers on push have been disabled to prevent Claude from reviewing after each push (issue #58)
-- **Optional label trigger:** You can uncomment the `pull_request` section in the workflow to enable triggering via PR labels
+- **No automatic triggers on push:** Automatic triggers have been disabled to prevent Claude from reviewing after each push (issue #58)
+- **Comment-based trigger:** Use `/claude-review` in a PR comment for easy access
 - **Actor restriction:** Only `amendez13` can trigger this workflow
 
 ### Claude Code (@claude) (`.github/workflows/claude.yml`)
@@ -947,10 +957,11 @@ Simply mention `@claude` in a comment or issue with your request:
 **Changed:**
 - Claude Code Review workflow (`.github/workflows/claude-code-review.yml`) no longer triggers automatically on PR pushes (issue #58)
 - Removed `pull_request` automatic triggers (types: `[opened, synchronize]`)
-- Changed to manual-only workflow using `workflow_dispatch`
+- Changed to on-demand workflow using comment trigger and manual dispatch
 
 **Added:**
-- Manual trigger input for PR number in Claude Code Review workflow
+- Comment-based trigger: Use `/claude-review` in any PR comment to trigger a review
+- `issue_comment` event listener for comment-based triggering
+- Manual trigger input for PR number in Claude Code Review workflow (`workflow_dispatch`)
 - Documentation section for Claude Code workflows in CI.md
-- Comments in workflow explaining how to enable optional label-based triggering
-- Instructions on how to manually trigger the workflow via GitHub Actions UI
+- Instructions for both comment-based and manual UI-based triggering


### PR DESCRIPTION
Changed Claude Code Review workflow to manual trigger only to prevent
automatic reviews after each push to a pull request.

Changes:
- Removed automatic pull_request triggers (opened, synchronize)
- Added workflow_dispatch for manual triggering via GitHub Actions UI
- Added pr_number input parameter for manual workflow runs
- Updated prompt to handle both manual and automatic (future) triggers
- Added documentation for Claude Code workflows in CI.md
- Added changelog entry documenting the change

The workflow can now be triggered manually:
1. Go to Actions tab → Claude Code Review
2. Click "Run workflow"
3. Enter the PR number to review

Optional: Users can uncomment the pull_request section to enable
label-based triggering if desired.

Closes #58