### PR TITLE
fix: Simplify conditional logic for /claude-review trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,13 +22,11 @@ on:
 
 jobs:
   claude-review:
-    # Only allow amendez13 to trigger, and only on PR comments with "/claude-review"
+    # Only allow amendez13 to trigger on comments with "/claude-review"
     if: |
       github.actor == 'amendez13' && (
         github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'issue_comment' &&
-         github.event.issue.pull_request &&
-         contains(github.event.comment.body, '/claude-review'))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude-review'))
       )
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed the github.event.issue.pull_request check that was preventing the workflow from triggering. The conditional now matches the pattern used in the working claude.yml workflow.

The issue was that the pull_request check in the if condition was not evaluating correctly, causing the job to be skipped even when triggered by valid PR comments.

Fixes the /claude-review comment trigger functionality.