### PR TITLE
feat: add date range filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Config files with sensitive data
 config/config.yaml
+config/config.vps.yaml
 
 # Reference photos (both naming conventions)
 reference_photos/
@@ -45,6 +46,7 @@ ENV/
 *.swo
 
 # Logs
+logs/
 *.log
 
 # Test coverage

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ processing:
   log_operations: true  # Enable audit logging
   dry_run: true
   batch_size: 50
+  date_range:
+    start: "2026-01-03"
+    end: "2026-01-07"
   image_extensions: [.jpg, .jpeg, .png, .heic]
 ```
 
@@ -158,6 +161,7 @@ processing:
 - **operation**: Operation mode - `copy` (default, safer) or `move` (destructive)
 - **log_operations**: If true, logs all operations to `operations.log`
 - **dry_run**: If true, lists matches without copying/moving files
+- **date_range**: Optional start/end dates (inclusive, `YYYY-MM-DD`) to limit which photos are processed
 
 ## Logging
 
@@ -249,6 +253,9 @@ python scripts/test_dropbox_connection.py
 ```bash
 # Dry run (preview matches without copying/moving)
 python scripts/organize_photos.py
+
+# Filter by date range (inclusive)
+python scripts/organize_photos.py --start-date 2026-01-03 --end-date 2026-01-07
 
 # Copy files (default, preserves originals)
 python scripts/organize_photos.py

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -101,6 +101,11 @@ processing:
   # Enable dry run mode (list matches without copying/moving files)
   dry_run: true
 
+  # Optional: process only photos between these dates (inclusive)
+  # date_range:
+  #   start: "2026-01-03"
+  #   end: "2026-01-07"
+
   # Batch size for processing photos
   batch_size: 50
 

--- a/docs/AWS_FACE_RECOGNITION_SETUP.md
+++ b/docs/AWS_FACE_RECOGNITION_SETUP.md
@@ -508,6 +508,17 @@ Default AWS Rekognition quotas:
 1. **Use thumbnails**: Process 256×256 thumbnails instead of full images
 2. **Fewer reference photos**: 3-5 good photos often suffice
 3. **Filter by date**: Only process photos from specific date ranges
+   - In `config/config.yaml`:
+     ```yaml
+     processing:
+       date_range:
+         start: "2026-01-03"
+         end: "2026-01-07"
+     ```
+   - Or via CLI:
+     ```bash
+     python scripts/organize_photos.py --start-date 2026-01-03 --end-date 2026-01-07
+     ```
 4. **Cache results**: Don't reprocess already-matched photos
 5. **Batch processing**: Process photos in batches during off-peak hours
 6. **Monitor usage**: Check AWS Cost Explorer regularly

--- a/tests/test_organize_photos.py
+++ b/tests/test_organize_photos.py
@@ -1,6 +1,7 @@
 """Unit tests for organize_photos script functions."""
 
 import sys
+from datetime import datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Generator
@@ -664,6 +665,43 @@ class TestGetReferencePhotos:
         assert len(photos) == 1
 
 
+class TestDateFiltering:
+    """Test date parsing and filtering helpers."""
+
+    def test_parse_date_value_valid(self, organize_photos_module: ModuleType) -> None:
+        result = organize_photos_module._parse_date_value("2026-01-03", "start_date")
+
+        assert result.isoformat() == "2026-01-03"
+
+    def test_parse_date_value_invalid(self, organize_photos_module: ModuleType) -> None:
+        with pytest.raises(ValueError):
+            organize_photos_module._parse_date_value("01-03-2026", "start_date")
+
+    def test_filter_files_by_date_inclusive(self, organize_photos_module: ModuleType) -> None:
+        mock_logger = Mock()
+
+        def make_file(date_str: str) -> Mock:
+            file_meta = Mock()
+            file_meta.client_modified = datetime.strptime(date_str, "%Y-%m-%d")
+            file_meta.server_modified = None
+            return file_meta
+
+        files = [
+            make_file("2026-01-02"),
+            make_file("2026-01-03"),
+            make_file("2026-01-07"),
+            make_file("2026-01-08"),
+        ]
+
+        start_date = organize_photos_module._parse_date_value("2026-01-03", "start_date")
+        end_date = organize_photos_module._parse_date_value("2026-01-07", "end_date")
+        filtered = organize_photos_module._filter_files_by_date(files, start_date, end_date, mock_logger)
+
+        assert len(filtered) == 2
+        assert filtered[0].client_modified.date().isoformat() == "2026-01-03"
+        assert filtered[1].client_modified.date().isoformat() == "2026-01-07"
+
+
 class TestValidateConfig:
     """Test _validate_config function."""
 
@@ -898,6 +936,8 @@ class TestMain:
         mock_args.dry_run = False
         mock_args.verbose = False
         mock_args.log_file = "operations.log"
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         # Mock argparse
         mock_parser = Mock()
@@ -933,6 +973,8 @@ dropbox:
         mock_args.dry_run = False
         mock_args.verbose = False
         mock_args.log_file = "operations.log"
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args
@@ -958,6 +1000,8 @@ dropbox:
         mock_args.dry_run = False
         mock_args.verbose = False
         mock_args.log_file = "operations.log"
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args
@@ -1003,6 +1047,8 @@ processing:
         mock_args.dry_run = True
         mock_args.verbose = False
         mock_args.log_file = "operations.log"
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args
@@ -1060,6 +1106,8 @@ processing:
         mock_args.dry_run = True
         mock_args.verbose = False
         mock_args.log_file = "operations.log"
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args
@@ -1118,6 +1166,8 @@ processing:
         mock_args.dry_run = True
         mock_args.verbose = False
         mock_args.log_file = "operations.log"
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args
@@ -1179,6 +1229,8 @@ processing:
         mock_args.dry_run = True
         mock_args.verbose = False
         mock_args.log_file = str(tmp_path / "operations.log")
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args
@@ -1246,6 +1298,8 @@ processing:
         mock_args.dry_run = True
         mock_args.verbose = True  # Verbose mode
         mock_args.log_file = str(tmp_path / "operations.log")
+        mock_args.start_date = None
+        mock_args.end_date = None
 
         mock_parser = Mock()
         mock_parser.parse_args.return_value = mock_args


### PR DESCRIPTION
## Summary
- add inclusive date range filtering for organizer runs via config or CLI
- log applied date range and skip files without timestamps
- document date range usage in README and AWS setup guide

## Testing
- venv/bin/pytest tests/test_organize_photos.py -k "DateFiltering or main"