### PR TITLE
docs: document Python 3.10 NumPy limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+#### Python 3.10 and NumPy compatibility
+
+The project currently supports Python 3.10 in CI. NumPy 2.3 and newer require
+Python 3.11+, so the base NumPy lower bound in `requirements.txt` must stay
+below 2.3 while Python 3.10 remains supported. Do not accept Dependabot bumps
+that raise the NumPy lower bound to 2.3 or 2.4 unless the Python 3.10 CI job is
+removed or the supported Python floor is raised.
+
 ### 3. Configure the Application
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 dropbox>=12.0.2
 PyYAML>=6.0.3
 python-dateutil>=2.9.0.post0
+# Keep this lower bound below NumPy 2.3 while Python 3.10 remains in CI.
+# NumPy 2.3+ requires Python 3.11+, so a Dependabot lower-bound bump
+# to 2.3/2.4 breaks the Python 3.10 job.
 numpy>=1.21.0
 
 # Secure credential storage (recommended for OAuth tokens)


### PR DESCRIPTION
Documents why NumPy lower-bound bumps to 2.3/2.4 are not mergeable while the project still supports Python 3.10 in CI.\n\nThis is the follow-up for blocked Dependabot PR #112.