### PR TITLE
fix(ci): target Python 3.12 only; fix numpy typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -67,13 +67,10 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-#### Python 3.10 and NumPy compatibility
+#### Python version
 
-The project currently supports Python 3.10 in CI. NumPy 2.3 and newer require
-Python 3.11+, so the base NumPy lower bound in `requirements.txt` must stay
-below 2.3 while Python 3.10 remains supported. Do not accept Dependabot bumps
-that raise the NumPy lower bound to 2.3 or 2.4 unless the Python 3.10 CI job is
-removed or the supported Python floor is raised.
+The project targets **Python 3.12** (CI and runtime). Earlier 3.10/3.11 support
+was dropped, so NumPy and other dependencies can track their latest releases.
 
 ### 3. Configure the Application
 
@@ -424,7 +421,7 @@ This project uses GitHub Actions for continuous integration. The CI pipeline run
 - Type checking (mypy)
 
 **Testing**
-- Unit tests across Python 3.10, 3.11, and 3.12
+- Unit tests on Python 3.12
 - Code coverage reporting
 
 **Security**

--- a/docs/FACE_RECOGNITION_LOCAL_SETUP.md
+++ b/docs/FACE_RECOGNITION_LOCAL_SETUP.md
@@ -34,7 +34,7 @@ The `face_recognition` library is built on top of dlib, which requires several s
 
 ### Required Software
 
-1. **Python 3.7 or higher**
+1. **Python 3.12 or higher**
    ```bash
    python3 --version
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 127
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -31,7 +31,7 @@ addopts = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
@@ -42,6 +42,7 @@ exclude = [
     'build',
     'dist',
 ]
+
 
 [tool.coverage.run]
 source = ["scripts"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,6 @@
 dropbox>=12.0.2
 PyYAML>=6.0.3
 python-dateutil>=2.9.0.post0
-# Keep this lower bound below NumPy 2.3 while Python 3.10 remains in CI.
-# NumPy 2.3+ requires Python 3.11+, so a Dependabot lower-bound bump
-# to 2.3/2.4 breaks the Python 3.10 job.
 numpy>=1.21.0
 
 # Secure credential storage (recommended for OAuth tokens)

--- a/scripts/face_recognizer/base_provider.py
+++ b/scripts/face_recognizer/base_provider.py
@@ -8,13 +8,14 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
+import numpy.typing as npt
 
 
 @dataclass
 class FaceEncoding:
     """Represents a face encoding with metadata."""
 
-    encoding: np.ndarray
+    encoding: npt.NDArray[np.float64]
     source: str  # Source file path or identifier
     confidence: Optional[float] = None
     bounding_box: Optional[Tuple[int, int, int, int]] = None  # (top, right, bottom, left)

--- a/scripts/github/branch-protection-config.json
+++ b/scripts/github/branch-protection-config.json
@@ -3,8 +3,6 @@
     "strict": true,
     "contexts": [
       "Lint and Code Quality",
-      "Test Python 3.10",
-      "Test Python 3.11",
       "Test Python 3.12",
       "Validate Configuration",
       "CI Status Check"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 def test_python_version():
     """Test that we're running on a supported Python version."""
-    assert sys.version_info >= (3, 10), "Python 3.10 or higher is required"
+    assert sys.version_info >= (3, 12), "Python 3.12 or higher is required"
 
 
 def test_imports():


### PR DESCRIPTION
## Problem
The **Lint and Code Quality** job (mypy) failed on every PR — including all 5 open Dependabot PRs:
\`\`\`
numpy/__init__.pyi: error: Type statement is only supported in Python 3.12 and greater  [syntax]
\`\`\`
NumPy 2.2+ ships PEP 695 type stubs (\`type X = ...\`, \`class Foo[T]\`) that require Python 3.12+ to parse, but mypy targeted \`python_version = 3.10\`. It worked last week because the installed numpy was older.

## Fix
Rather than pin or `follow_imports = skip` numpy (which would stop type-checking our numpy usage — a real quality loss, since the `face_recognizer` providers use numpy), **drop 3.10/3.11 and target 3.12 only**. mypy then parses the latest numpy stubs natively and type-checks numpy against the actual runtime version — no pin, no skew, no skip.

- mypy `python_version` 3.10 → 3.12; black `target-version` → `py312`
- CI test matrix `3.10/3.11/3.12` → `3.12`
- drop the stale "keep numpy <2.3 for the 3.10 job" requirements note

Also fixes a **latent typing bug** this surfaced (numpy was effectively unchecked before): `FaceEncoding.encoding` was a bare `np.ndarray` (mypy `--strict` `[type-arg]`) → `npt.NDArray[np.float64]`.

**Verified locally:** black / isort / flake8 / mypy all green under 3.12 with the latest numpy (2.5), no pin/skip; numpy usage is genuinely type-checked.

Unblocks Dependabot #124–#128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)