### PR TITLE
ci: run CI on the self-hosted Fargate runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Lint and Code Quality
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
 
     steps:
     - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
 
   test:
     name: Test Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
 
   coverage:
     name: Coverage Check (95% target)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
 
     steps:
     - name: Checkout code
@@ -117,7 +117,7 @@ jobs:
 
   security:
     name: Security Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
 
     steps:
     - name: Checkout code
@@ -148,7 +148,7 @@ jobs:
 
   validate-config:
     name: Validate Configuration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
 
     steps:
     - name: Checkout code
@@ -187,7 +187,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
     # Dropbox secrets are only available in trusted contexts.
     if: vars.RUN_INTEGRATION_TESTS == 'true' && github.event_name != 'pull_request'
 
@@ -247,7 +247,7 @@ jobs:
 
   build-status:
     name: CI Status Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, fargate]
     needs: [lint, test, coverage, security, validate-config]
     if: always()
 


### PR DESCRIPTION
Moves all `ci.yml` jobs from `ubuntu-latest` to `[self-hosted, fargate]`, matching the other repos. Jobs already self-provision Python via `actions/setup-python` (no `container:` needed — Fargate has no DinD). Removes this repo's dependence on GitHub-hosted minutes / the org billing block.

Note: `claude.yml` / `claude-code-review.yml` are left on `ubuntu-latest` for now (separate from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)